### PR TITLE
Use pytest

### DIFF
--- a/environment_ci.yml
+++ b/environment_ci.yml
@@ -8,6 +8,7 @@ dependencies:
   - wheel==0.29.0
   - coverage==4.0.3
   - python-coveralls==2.7.0
+  - pytest==3.0.5
   - dask==0.13.0
   - numpy==1.11.3
   - scipy==0.18.1

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,21 @@
 
 import setuptools
 from setuptools import setup
+from setuptools.command.test import test as TestCommand
 import versioneer
+
+
+class PyTest(TestCommand):
+    description = "Run test suite with pytest"
+
+    def finalize_options(self):
+        TestCommand.finalize_options(self)
+        self.test_args = []
+        self.test_suite = True
+
+    def run_tests(self):
+        import pytest
+        pytest.main(self.test_args)
 
 
 with open("README.rst") as readme_file:
@@ -19,6 +33,10 @@ test_requirements = [
     "pytest",
 ]
 
+cmdclasses = {
+    "test": PyTest,
+}
+cmdclasses.update(versioneer.get_cmdclass())
 
 setup(
     name="dask-ndfilters",
@@ -28,7 +46,7 @@ setup(
     author="John Kirkham",
     author_email="kirkhamj@janelia.hhmi.org",
     url="https://github.com/jakirkham/dask-ndfilters",
-    cmdclass=versioneer.get_cmdclass(),
+    cmdclass=cmdclasses,
     packages=setuptools.find_packages(exclude=["tests*"]),
     include_package_data=True,
     install_requires=requirements,
@@ -47,6 +65,5 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
     ],
-    test_suite="tests",
     tests_require=test_requirements
 )

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ requirements = [
 ]
 
 test_requirements = [
-    # TODO: put package test requirements here
+    "pytest",
 ]
 
 


### PR DESCRIPTION
Switch to using pytest for running the test suite. Add pytest as a requirement for running the tests and running on CIs. Also include a command class to run pytest as if running the test suite normally (a la `python setup.py test`).