### PR TITLE
Refactor size normalization function

### DIFF
--- a/dask_ndfilters/_utils.py
+++ b/dask_ndfilters/_utils.py
@@ -6,6 +6,8 @@ import inspect
 import numbers
 import re
 
+import numpy
+
 
 try:
     from itertools import imap, izip
@@ -111,3 +113,25 @@ def _get_depth_boundary(ndim, depth, boundary=None):
             boundary[i] = "reflect"
 
     return depth, boundary
+
+
+def _get_size(ndim, size):
+    if not isinstance(ndim, numbers.Integral):
+        raise TypeError("The ndim must be of integral type.")
+
+    if isinstance(size, numbers.Number):
+        size = ndim * (size,)
+    size = numpy.array(size)
+
+    if size.ndim != 1:
+        raise RuntimeError("The size must have only one dimension.")
+    if len(size) != ndim:
+        raise RuntimeError(
+            "The size must have a length equal to the number of dimensions."
+        )
+    if not issubclass(size.dtype.type, numbers.Integral):
+        raise TypeError("The size must be of integral type.")
+
+    size = tuple(size)
+
+    return size

--- a/dask_ndfilters/order.py
+++ b/dask_ndfilters/order.py
@@ -18,15 +18,7 @@ def _get_footprint(ndim, size=None, footprint=None):
 
     # Get a footprint based on the size.
     if size is not None:
-        if isinstance(size, numbers.Number):
-            size = ndim * (size,)
-        size = numpy.array(size)
-
-        if size.ndim != 1:
-            raise RuntimeError("The size must have only one dimension.")
-        if not issubclass(size.dtype.type, numbers.Integral):
-            raise TypeError("The size must be of integral type.")
-
+        size = _utils._get_size(ndim, size)
         footprint = numpy.ones(size, dtype=bool)
 
     # Validate the footprint.

--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -85,3 +85,18 @@ def test__update_wrapper():
 def test_errs__get_depth_boundary(err_type, ndim, depth, boundary):
     with pytest.raises(err_type):
         _utils._get_depth_boundary(ndim, depth, boundary)
+
+
+@pytest.mark.parametrize(
+    "err_type, ndim, size",
+    [
+        (TypeError, 1.0, 1),
+        (RuntimeError, 1, [[1]]),
+        (TypeError, 1, 1.0),
+        (TypeError, 1, [1.0]),
+        (RuntimeError, 1, [1, 1]),
+    ]
+)
+def test_errs__get_size(err_type, ndim, size):
+    with pytest.raises(err_type):
+        _utils._get_size(ndim, size)


### PR DESCRIPTION
As size normalization of filters is becoming more generally useful, refactor a function for this purpose from `_get_footprint` and add it to `_utils`. Also add tests for this function to make sure it properly handles different unacceptable values.