### PR TITLE
Add other Gaussian filters

### DIFF
--- a/dask_ndfilters/core.py
+++ b/dask_ndfilters/core.py
@@ -11,6 +11,7 @@ from dask_ndfilters.edge import (
 
 from dask_ndfilters.gaussian import (
     gaussian_filter,
+    gaussian_gradient_magnitude,
 )
 
 from dask_ndfilters.order import (

--- a/dask_ndfilters/core.py
+++ b/dask_ndfilters/core.py
@@ -12,6 +12,7 @@ from dask_ndfilters.edge import (
 from dask_ndfilters.gaussian import (
     gaussian_filter,
     gaussian_gradient_magnitude,
+    gaussian_laplace,
 )
 
 from dask_ndfilters.order import (

--- a/dask_ndfilters/core.py
+++ b/dask_ndfilters/core.py
@@ -9,6 +9,10 @@ from dask_ndfilters.edge import (
     sobel,
 )
 
+from dask_ndfilters.gaussian import (
+    gaussian_filter,
+)
+
 from dask_ndfilters.order import (
     minimum_filter,
     median_filter,
@@ -18,6 +22,5 @@ from dask_ndfilters.order import (
 )
 
 from dask_ndfilters.smooth import (
-    gaussian_filter,
     uniform_filter,
 )

--- a/dask_ndfilters/gaussian.py
+++ b/dask_ndfilters/gaussian.py
@@ -99,3 +99,31 @@ def gaussian_gradient_magnitude(input,
     )
 
     return result
+
+
+@_utils._update_wrapper(scipy.ndimage.filters.gaussian_laplace)
+def gaussian_laplace(input,
+                     sigma,
+                     mode='reflect',
+                     cval=0.0,
+                     truncate=4.0,
+                     **kwargs):
+    sigma = _get_sigmas(input, sigma)
+    depth = _get_border(input, sigma, truncate)
+
+    depth, boundary = _utils._get_depth_boundary(input.ndim, depth, "none")
+
+    result = input.map_overlap(
+        scipy.ndimage.filters.gaussian_laplace,
+        depth=depth,
+        boundary=boundary,
+        dtype=input.dtype,
+        name=scipy.ndimage.filters.gaussian_laplace.__name__,
+        sigma=sigma,
+        mode=mode,
+        cval=cval,
+        truncate=truncate,
+        **kwargs
+    )
+
+    return result

--- a/dask_ndfilters/gaussian.py
+++ b/dask_ndfilters/gaussian.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+
+
+import numbers
+
+import numpy
+import scipy.ndimage.filters
+
+import dask_ndfilters._utils as _utils
+
+
+def _get_sigmas(input, sigma):
+    ndim = input.ndim
+
+    nsigmas = numpy.array(sigma)
+    if nsigmas.ndim == 0:
+        nsigmas = numpy.array(ndim * [nsigmas[()]])
+
+    if nsigmas.ndim != 1:
+        raise RuntimeError(
+            "Must have a single sigma or a single sequence."
+        )
+
+    if ndim != len(nsigmas):
+        raise RuntimeError(
+            "Must have an equal number of sigmas to input dimensions."
+        )
+
+    if not issubclass(nsigmas.dtype.type, numbers.Real):
+        raise TypeError("Must have real sigmas.")
+
+    nsigmas = tuple(nsigmas)
+
+    return nsigmas
+
+
+def _get_border(input, sigma, truncate):
+    sigma = numpy.array(_get_sigmas(input, sigma))
+
+    if not isinstance(truncate, numbers.Real):
+        raise TypeError("Must have a real truncate value.")
+
+    half_shape = tuple(numpy.ceil(sigma * truncate).astype(int))
+
+    return half_shape
+
+
+@_utils._update_wrapper(scipy.ndimage.filters.gaussian_filter)
+def gaussian_filter(input,
+                    sigma,
+                    order=0,
+                    mode='reflect',
+                    cval=0.0,
+                    truncate=4.0):
+    sigma = _get_sigmas(input, sigma)
+    depth = _get_border(input, sigma, truncate)
+
+    depth, boundary = _utils._get_depth_boundary(input.ndim, depth, "none")
+
+    result = input.map_overlap(
+        scipy.ndimage.filters.gaussian_filter,
+        depth=depth,
+        boundary=boundary,
+        dtype=input.dtype,
+        name=scipy.ndimage.filters.gaussian_filter.__name__,
+        sigma=sigma,
+        order=order,
+        mode=mode,
+        cval=cval,
+        truncate=truncate
+    )
+
+    return result

--- a/dask_ndfilters/gaussian.py
+++ b/dask_ndfilters/gaussian.py
@@ -71,3 +71,31 @@ def gaussian_filter(input,
     )
 
     return result
+
+
+@_utils._update_wrapper(scipy.ndimage.filters.gaussian_gradient_magnitude)
+def gaussian_gradient_magnitude(input,
+                                sigma,
+                                mode='reflect',
+                                cval=0.0,
+                                truncate=4.0,
+                                **kwargs):
+    sigma = _get_sigmas(input, sigma)
+    depth = _get_border(input, sigma, truncate)
+
+    depth, boundary = _utils._get_depth_boundary(input.ndim, depth, "none")
+
+    result = input.map_overlap(
+        scipy.ndimage.filters.gaussian_gradient_magnitude,
+        depth=depth,
+        boundary=boundary,
+        dtype=input.dtype,
+        name=scipy.ndimage.filters.gaussian_gradient_magnitude.__name__,
+        sigma=sigma,
+        mode=mode,
+        cval=cval,
+        truncate=truncate,
+        **kwargs
+    )
+
+    return result

--- a/dask_ndfilters/smooth.py
+++ b/dask_ndfilters/smooth.py
@@ -7,70 +7,7 @@ import numpy
 import scipy.ndimage.filters
 
 import dask_ndfilters._utils as _utils
-
-
-def _get_sigmas(input, sigma):
-    ndim = input.ndim
-
-    nsigmas = numpy.array(sigma)
-    if nsigmas.ndim == 0:
-        nsigmas = numpy.array(ndim * [nsigmas[()]])
-
-    if nsigmas.ndim != 1:
-        raise RuntimeError(
-            "Must have a single sigma or a single sequence."
-        )
-
-    if ndim != len(nsigmas):
-        raise RuntimeError(
-            "Must have an equal number of sigmas to input dimensions."
-        )
-
-    if not issubclass(nsigmas.dtype.type, numbers.Real):
-        raise TypeError("Must have real sigmas.")
-
-    nsigmas = tuple(nsigmas)
-
-    return nsigmas
-
-
-def _get_border(input, sigma, truncate):
-    sigma = numpy.array(_get_sigmas(input, sigma))
-
-    if not isinstance(truncate, numbers.Real):
-        raise TypeError("Must have a real truncate value.")
-
-    half_shape = tuple(numpy.ceil(sigma * truncate).astype(int))
-
-    return half_shape
-
-
-@_utils._update_wrapper(scipy.ndimage.filters.gaussian_filter)
-def gaussian_filter(input,
-                    sigma,
-                    order=0,
-                    mode='reflect',
-                    cval=0.0,
-                    truncate=4.0):
-    sigma = _get_sigmas(input, sigma)
-    depth = _get_border(input, sigma, truncate)
-
-    depth, boundary = _utils._get_depth_boundary(input.ndim, depth, "none")
-
-    result = input.map_overlap(
-        scipy.ndimage.filters.gaussian_filter,
-        depth=depth,
-        boundary=boundary,
-        dtype=input.dtype,
-        name=scipy.ndimage.filters.gaussian_filter.__name__,
-        sigma=sigma,
-        order=order,
-        mode=mode,
-        cval=cval,
-        truncate=truncate
-    )
-
-    return result
+from dask_ndfilters.gaussian import gaussian_filter
 
 
 @_utils._update_wrapper(scipy.ndimage.filters.uniform_filter)

--- a/tests/test_gaussian.py
+++ b/tests/test_gaussian.py
@@ -23,12 +23,18 @@ import dask_ndfilters as da_ndf
         (TypeError, 1.0, 4.0 + 0.0j),
     ]
 )
-def test_gaussian_filter_params(err_type, sigma, truncate):
+@pytest.mark.parametrize(
+    "da_func",
+    [
+        da_ndf.gaussian_filter,
+    ]
+)
+def test_gaussian_filters_params(da_func, err_type, sigma, truncate):
     a = np.arange(140.0).reshape(10, 14)
     d = da.from_array(a, chunks=(5, 7))
 
     with pytest.raises(err_type):
-        da_ndf.gaussian_filter(d, sigma, truncate=truncate)
+        da_func(d, sigma, truncate=truncate)
 
 
 @pytest.mark.parametrize(
@@ -43,7 +49,13 @@ def test_gaussian_filter_params(err_type, sigma, truncate):
 @pytest.mark.parametrize(
     "order", [0, 1, 2, 3]
 )
-def test_gaussian_identity(order, sigma, truncate):
+@pytest.mark.parametrize(
+    "sp_func, da_func",
+    [
+        (sp_ndf.gaussian_filter, da_ndf.gaussian_filter),
+    ]
+)
+def test_gaussian_filters_identity(sp_func, da_func, order, sigma, truncate):
     a = np.arange(140.0).reshape(10, 14)
     d = da.from_array(a, chunks=(5, 7))
 
@@ -55,12 +67,12 @@ def test_gaussian_identity(order, sigma, truncate):
         )
 
     dau.assert_eq(
-        d, da_ndf.gaussian_filter(d, sigma, order, truncate=truncate)
+        d, da_func(d, sigma, order, truncate=truncate)
     )
 
     dau.assert_eq(
-        sp_ndf.gaussian_filter(a, sigma, order, truncate=truncate),
-        da_ndf.gaussian_filter(d, sigma, order, truncate=truncate)
+        sp_func(a, sigma, order, truncate=truncate),
+        da_func(d, sigma, order, truncate=truncate)
     )
 
 
@@ -84,12 +96,18 @@ def test_gaussian_identity(order, sigma, truncate):
         (2, 3),
     ]
 )
-def test_gaussian_compare(order, sigma, truncate):
+@pytest.mark.parametrize(
+    "sp_func, da_func",
+    [
+        (sp_ndf.gaussian_filter, da_ndf.gaussian_filter),
+    ]
+)
+def test_gaussian_filters_compare(sp_func, da_func, order, sigma, truncate):
     s = (100, 110)
     a = np.arange(float(np.prod(s))).reshape(s)
     d = da.from_array(a, chunks=(50, 55))
 
     dau.assert_eq(
-        sp_ndf.gaussian_filter(a, sigma, order, truncate=truncate),
-        da_ndf.gaussian_filter(d, sigma, order, truncate=truncate)
+        sp_func(a, sigma, order, truncate=truncate),
+        da_func(d, sigma, order, truncate=truncate)
     )

--- a/tests/test_gaussian.py
+++ b/tests/test_gaussian.py
@@ -110,6 +110,9 @@ def test_gaussian_filters_compare(sp_func, da_func, sigma, truncate):
 @pytest.mark.parametrize(
     "sigma, truncate",
     [
+        (0.0, 0.0),
+        (1.0, 0.0),
+        (0.0, 1.0),
         (1.0, 2.0),
         (1.0, 4.0),
         (2.0, 2.0),

--- a/tests/test_gaussian.py
+++ b/tests/test_gaussian.py
@@ -27,6 +27,7 @@ import dask_ndfilters as da_ndf
     "da_func",
     [
         da_ndf.gaussian_filter,
+        da_ndf.gaussian_gradient_magnitude,
     ]
 )
 def test_gaussian_filters_params(da_func, err_type, sigma, truncate):
@@ -53,6 +54,7 @@ def test_gaussian_filters_params(da_func, err_type, sigma, truncate):
     "sp_func, da_func",
     [
         (sp_ndf.gaussian_filter, da_ndf.gaussian_filter),
+        (sp_ndf.gaussian_gradient_magnitude, da_ndf.gaussian_gradient_magnitude),
     ]
 )
 def test_gaussian_filters_identity(sp_func, da_func, order, sigma, truncate):
@@ -100,6 +102,7 @@ def test_gaussian_filters_identity(sp_func, da_func, order, sigma, truncate):
     "sp_func, da_func",
     [
         (sp_ndf.gaussian_filter, da_ndf.gaussian_filter),
+        (sp_ndf.gaussian_gradient_magnitude, da_ndf.gaussian_gradient_magnitude),
     ]
 )
 def test_gaussian_filters_compare(sp_func, da_func, order, sigma, truncate):

--- a/tests/test_gaussian.py
+++ b/tests/test_gaussian.py
@@ -28,6 +28,7 @@ import dask_ndfilters as da_ndf
     [
         da_ndf.gaussian_filter,
         da_ndf.gaussian_gradient_magnitude,
+        da_ndf.gaussian_laplace,
     ]
 )
 def test_gaussian_filters_params(da_func, err_type, sigma, truncate):
@@ -92,6 +93,7 @@ def test_gaussian_filters_identity(sp_func, da_func, order, sigma, truncate):
     [
         (sp_ndf.gaussian_filter, da_ndf.gaussian_filter),
         (sp_ndf.gaussian_gradient_magnitude, da_ndf.gaussian_gradient_magnitude),
+        (sp_ndf.gaussian_laplace, da_ndf.gaussian_laplace),
     ]
 )
 def test_gaussian_filters_compare(sp_func, da_func, sigma, truncate):

--- a/tests/test_gaussian.py
+++ b/tests/test_gaussian.py
@@ -54,7 +54,6 @@ def test_gaussian_filters_params(da_func, err_type, sigma, truncate):
     "sp_func, da_func",
     [
         (sp_ndf.gaussian_filter, da_ndf.gaussian_filter),
-        (sp_ndf.gaussian_gradient_magnitude, da_ndf.gaussian_gradient_magnitude),
     ]
 )
 def test_gaussian_filters_identity(sp_func, da_func, order, sigma, truncate):
@@ -89,6 +88,34 @@ def test_gaussian_filters_identity(sp_func, da_func, order, sigma, truncate):
     ]
 )
 @pytest.mark.parametrize(
+    "sp_func, da_func",
+    [
+        (sp_ndf.gaussian_filter, da_ndf.gaussian_filter),
+        (sp_ndf.gaussian_gradient_magnitude, da_ndf.gaussian_gradient_magnitude),
+    ]
+)
+def test_gaussian_filters_compare(sp_func, da_func, sigma, truncate):
+    s = (100, 110)
+    a = np.arange(float(np.prod(s))).reshape(s)
+    d = da.from_array(a, chunks=(50, 55))
+
+    dau.assert_eq(
+        sp_func(a, sigma, truncate=truncate),
+        da_func(d, sigma, truncate=truncate)
+    )
+
+
+@pytest.mark.parametrize(
+    "sigma, truncate",
+    [
+        (1.0, 2.0),
+        (1.0, 4.0),
+        (2.0, 2.0),
+        (2.0, 4.0),
+        ((1.0, 2.0), 4.0),
+    ]
+)
+@pytest.mark.parametrize(
     "order", [
         0,
         1,
@@ -102,10 +129,9 @@ def test_gaussian_filters_identity(sp_func, da_func, order, sigma, truncate):
     "sp_func, da_func",
     [
         (sp_ndf.gaussian_filter, da_ndf.gaussian_filter),
-        (sp_ndf.gaussian_gradient_magnitude, da_ndf.gaussian_gradient_magnitude),
     ]
 )
-def test_gaussian_filters_compare(sp_func, da_func, order, sigma, truncate):
+def test_gaussian_derivative_filters_compare(sp_func, da_func, order, sigma, truncate):
     s = (100, 110)
     a = np.arange(float(np.prod(s))).reshape(s)
     d = da.from_array(a, chunks=(50, 55))

--- a/tests/test_gaussian.py
+++ b/tests/test_gaussian.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+
+import pytest
+
+import numpy as np
+import scipy.ndimage.filters as sp_ndf
+
+import dask.array as da
+import dask.array.utils as dau
+
+import dask_ndfilters as da_ndf
+
+
+@pytest.mark.parametrize(
+    "err_type, sigma, truncate",
+    [
+        (RuntimeError, [[1.0]], 4.0),
+        (RuntimeError, [1.0], 4.0),
+        (TypeError, 1.0 + 0.0j, 4.0),
+        (TypeError, 1.0, 4.0 + 0.0j),
+    ]
+)
+def test_gaussian_filter_params(err_type, sigma, truncate):
+    a = np.arange(140.0).reshape(10, 14)
+    d = da.from_array(a, chunks=(5, 7))
+
+    with pytest.raises(err_type):
+        da_ndf.gaussian_filter(d, sigma, truncate=truncate)
+
+
+@pytest.mark.parametrize(
+    "sigma, truncate",
+    [
+        (0.0, 0.0),
+        (0.0, 1.0),
+        (0.0, 4.0),
+        (1.0, 0.0),
+    ]
+)
+@pytest.mark.parametrize(
+    "order", [0, 1, 2, 3]
+)
+def test_gaussian_identity(order, sigma, truncate):
+    a = np.arange(140.0).reshape(10, 14)
+    d = da.from_array(a, chunks=(5, 7))
+
+    if order % 2 == 1 and sigma != 0 and truncate == 0:
+        pytest.skip(
+            "SciPy zeros the result of a Gaussian filter with odd derivatives"
+            " when sigma is non-zero, truncate is zero, and derivative is odd."
+            "\n\nxref: https://github.com/scipy/scipy/issues/7364"
+        )
+
+    dau.assert_eq(
+        d, da_ndf.gaussian_filter(d, sigma, order, truncate=truncate)
+    )
+
+    dau.assert_eq(
+        sp_ndf.gaussian_filter(a, sigma, order, truncate=truncate),
+        da_ndf.gaussian_filter(d, sigma, order, truncate=truncate)
+    )
+
+
+@pytest.mark.parametrize(
+    "sigma, truncate",
+    [
+        (1.0, 2.0),
+        (1.0, 4.0),
+        (2.0, 2.0),
+        (2.0, 4.0),
+        ((1.0, 2.0), 4.0),
+    ]
+)
+@pytest.mark.parametrize(
+    "order", [
+        0,
+        1,
+        2,
+        3,
+        (0, 1),
+        (2, 3),
+    ]
+)
+def test_gaussian_compare(order, sigma, truncate):
+    s = (100, 110)
+    a = np.arange(float(np.prod(s))).reshape(s)
+    d = da.from_array(a, chunks=(50, 55))
+
+    dau.assert_eq(
+        sp_ndf.gaussian_filter(a, sigma, order, truncate=truncate),
+        da_ndf.gaussian_filter(d, sigma, order, truncate=truncate)
+    )

--- a/tests/test_smooth.py
+++ b/tests/test_smooth.py
@@ -15,23 +15,6 @@ import dask_ndfilters as da_ndf
 
 
 @pytest.mark.parametrize(
-    "err_type, sigma, truncate",
-    [
-        (RuntimeError, [[1.0]], 4.0),
-        (RuntimeError, [1.0], 4.0),
-        (TypeError, 1.0 + 0.0j, 4.0),
-        (TypeError, 1.0, 4.0 + 0.0j),
-    ]
-)
-def test_gaussian_filter_params(err_type, sigma, truncate):
-    a = np.arange(140.0).reshape(10, 14)
-    d = da.from_array(a, chunks=(5, 7))
-
-    with pytest.raises(err_type):
-        da_ndf.gaussian_filter(d, sigma, truncate=truncate)
-
-
-@pytest.mark.parametrize(
     "err_type, size, origin",
     [
         (TypeError, 3.0, 0),
@@ -51,39 +34,6 @@ def test_uniform_filter_params(err_type, size, origin):
 
 
 @pytest.mark.parametrize(
-    "sigma, truncate",
-    [
-        (0.0, 0.0),
-        (0.0, 1.0),
-        (0.0, 4.0),
-        (1.0, 0.0),
-    ]
-)
-@pytest.mark.parametrize(
-    "order", [0, 1, 2, 3]
-)
-def test_gaussian_identity(order, sigma, truncate):
-    a = np.arange(140.0).reshape(10, 14)
-    d = da.from_array(a, chunks=(5, 7))
-
-    if order % 2 == 1 and sigma != 0 and truncate == 0:
-        pytest.skip(
-            "SciPy zeros the result of a Gaussian filter with odd derivatives"
-            " when sigma is non-zero, truncate is zero, and derivative is odd."
-            "\n\nxref: https://github.com/scipy/scipy/issues/7364"
-        )
-
-    dau.assert_eq(
-        d, da_ndf.gaussian_filter(d, sigma, order, truncate=truncate)
-    )
-
-    dau.assert_eq(
-        sp_ndf.gaussian_filter(a, sigma, order, truncate=truncate),
-        da_ndf.gaussian_filter(d, sigma, order, truncate=truncate)
-    )
-
-
-@pytest.mark.parametrize(
     "size, origin",
     [
         (1, 0),
@@ -100,37 +50,6 @@ def test_uniform_identity(size, origin):
     dau.assert_eq(
         sp_ndf.uniform_filter(a, size, origin=origin),
         da_ndf.uniform_filter(d, size, origin=origin)
-    )
-
-
-@pytest.mark.parametrize(
-    "sigma, truncate",
-    [
-        (1.0, 2.0),
-        (1.0, 4.0),
-        (2.0, 2.0),
-        (2.0, 4.0),
-        ((1.0, 2.0), 4.0),
-    ]
-)
-@pytest.mark.parametrize(
-    "order", [
-        0,
-        1,
-        2,
-        3,
-        (0, 1),
-        (2, 3),
-    ]
-)
-def test_gaussian_compare(order, sigma, truncate):
-    s = (100, 110)
-    a = np.arange(float(np.prod(s))).reshape(s)
-    d = da.from_array(a, chunks=(50, 55))
-
-    dau.assert_eq(
-        sp_ndf.gaussian_filter(a, sigma, order, truncate=truncate),
-        da_ndf.gaussian_filter(d, sigma, order, truncate=truncate)
     )
 
 


### PR DESCRIPTION
Partially addresses issue ( https://github.com/jakirkham/dask-ndfilters/issues/13 ).

Adds a module for Gaussian filters and associated tests. Includes the following wrapped functions from [`scipy.ndimage.filters`]( https://docs.scipy.org/doc/scipy-0.19.0/reference/ndimage.html#filters ) with tests:

* [`gaussian_gradient_magnitude`]( https://docs.scipy.org/doc/scipy-0.19.0/reference/generated/scipy.ndimage.gaussian_gradient_magnitude.html )
* [`gaussian_laplace`]( https://docs.scipy.org/doc/scipy-0.19.0/reference/generated/scipy.ndimage.gaussian_laplace.html )

Also relocates `gaussian_filter` to this new module.