### PR TITLE
Convert all depths to ints

### DIFF
--- a/dask_ndfilters/_utils.py
+++ b/dask_ndfilters/_utils.py
@@ -87,6 +87,8 @@ def _get_depth_boundary(ndim, depth, boundary=None):
     if not all(map(lambda d: d >= 0, depth.values())):
         raise ValueError("Expected positive semidefinite values for `depth`.")
 
+    depth = dict([(a, int(d)) for a, d in depth.items()])
+
     if (boundary is None) or isinstance(boundary, strlike):
         boundary = ndim * (boundary,)
     if not isinstance(boundary, collections.Sized):

--- a/tests/test__conv.py
+++ b/tests/test__conv.py
@@ -49,6 +49,26 @@ def test_convolutions_params(da_func,
 
 
 @pytest.mark.parametrize(
+    "da_func",
+    [
+        da_ndf.convolve,
+        da_ndf.correlate,
+    ]
+)
+def test_convolutions_shape_type(da_func):
+    weights = np.ones((1, 1))
+
+    a = np.arange(140.0).reshape(10, 14)
+    d = da.from_array(a, chunks=(5, 7))
+
+    assert all([(type(s) is int) for s in d.shape])
+
+    d2 = da_func(d, weights)
+
+    assert all([(type(s) is int) for s in d2.shape])
+
+
+@pytest.mark.parametrize(
     "sp_func, da_func",
     [
         (sp_ndf.convolve, da_ndf.convolve),

--- a/tests/test__gaussian.py
+++ b/tests/test__gaussian.py
@@ -79,6 +79,28 @@ def test_gaussian_filters_identity(sp_func, da_func, order, sigma, truncate):
 
 
 @pytest.mark.parametrize(
+    "da_func",
+    [
+        da_ndf.gaussian_filter,
+        da_ndf.gaussian_gradient_magnitude,
+        da_ndf.gaussian_laplace,
+    ]
+)
+def test_gaussian_filter_shape_type(da_func):
+    sigma = 1.0
+    truncate = 4.0
+
+    a = np.arange(140.0).reshape(10, 14)
+    d = da.from_array(a, chunks=(5, 7))
+
+    assert all([(type(s) is int) for s in d.shape])
+
+    d2 = da_func(d, sigma=sigma, truncate=truncate)
+
+    assert all([(type(s) is int) for s in d2.shape])
+
+
+@pytest.mark.parametrize(
     "sigma, truncate",
     [
         (1.0, 2.0),

--- a/tests/test__generic.py
+++ b/tests/test__generic.py
@@ -57,6 +57,26 @@ def test_generic_filters_params(da_func,
 
 
 @pytest.mark.parametrize(
+    "da_func",
+    [
+        da_ndf.generic_filter,
+    ]
+)
+def test_generic_filter_shape_type(da_func):
+    function = lambda x: x
+    size = 1
+
+    a = np.arange(140.0).reshape(10, 14)
+    d = da.from_array(a, chunks=(5, 7))
+
+    assert all([(type(s) is int) for s in d.shape])
+
+    d2 = da_func(d, function, size=size)
+
+    assert all([(type(s) is int) for s in d2.shape])
+
+
+@pytest.mark.parametrize(
     "sp_func, da_func",
     [
         (sp_ndf.generic_filter, da_ndf.generic_filter),

--- a/tests/test__order.py
+++ b/tests/test__order.py
@@ -61,6 +61,30 @@ def test_order_filter_params(da_func,
 
 
 @pytest.mark.parametrize(
+    "da_func, extra_kwargs",
+    [
+        (da_ndf.minimum_filter, {}),
+        (da_ndf.median_filter, {}),
+        (da_ndf.maximum_filter, {}),
+        (da_ndf.rank_filter, {"rank": 0}),
+        (da_ndf.percentile_filter, {"percentile": 0}),
+    ]
+)
+def test_ordered_filter_shape_type(da_func,
+                                   extra_kwargs):
+    size = 1
+
+    a = np.arange(140.0).reshape(10, 14)
+    d = da.from_array(a, chunks=(5, 7))
+
+    assert all([(type(s) is int) for s in d.shape])
+
+    d2 = da_func(d, size=size, **extra_kwargs)
+
+    assert all([(type(s) is int) for s in d2.shape])
+
+
+@pytest.mark.parametrize(
     "sp_func, da_func, extra_kwargs",
     [
         (sp_ndf.minimum_filter, da_ndf.minimum_filter, {}),

--- a/tests/test__smooth.py
+++ b/tests/test__smooth.py
@@ -33,6 +33,20 @@ def test_uniform_filter_params(err_type, size, origin):
         da_ndf.uniform_filter(d, size, origin=origin)
 
 
+def test_uniform_shape_type():
+    size = 1
+    origin = 0
+
+    a = np.arange(140.0).reshape(10, 14)
+    d = da.from_array(a, chunks=(5, 7))
+
+    assert all([(type(s) is int) for s in d.shape])
+
+    d2 = da_ndf.uniform_filter(d, size, origin=origin)
+
+    assert all([(type(s) is int) for s in d2.shape])
+
+
 @pytest.mark.parametrize(
     "size, origin",
     [


### PR DESCRIPTION
Fixes https://github.com/dask-image/dask-ndfilters/issues/26

Make sure the depths for all axes are converted to `int`s regardless of the original type or format of `depth`. Also include some tests to ensure that this fixes the `shape` type issue of resulting Dask Arrays with a variety of functions.