### PR TITLE
More tests for `_utils`

### DIFF
--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -100,3 +100,18 @@ def test_errs__get_depth_boundary(err_type, ndim, depth, boundary):
 def test_errs__get_size(err_type, ndim, size):
     with pytest.raises(err_type):
         _utils._get_size(ndim, size)
+
+
+@pytest.mark.parametrize(
+    "err_type, size, origin",
+    [
+        (TypeError, [1], 1.0),
+        (TypeError, [1], [1.0]),
+        (RuntimeError, [1], [[1]]),
+        (RuntimeError, [1], [1, 1]),
+        (ValueError, [1], [2]),
+    ]
+)
+def test_errs__get_origin(err_type, size, origin):
+    with pytest.raises(err_type):
+        _utils._get_origin(size, origin)

--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -7,6 +7,8 @@ import inspect
 
 import pytest
 
+import numpy
+
 from dask_ndfilters import _utils
 
 
@@ -115,3 +117,17 @@ def test_errs__get_size(err_type, ndim, size):
 def test_errs__get_origin(err_type, size, origin):
     with pytest.raises(err_type):
         _utils._get_origin(size, origin)
+
+
+@pytest.mark.parametrize(
+    "err_type, ndim, size, footprint",
+    [
+        (RuntimeError, 1, None, None),
+        (RuntimeError, 1, [2], numpy.ones((2,), dtype=bool)),
+        (RuntimeError, 1, None, numpy.ones((1, 2), dtype=bool)),
+        (RuntimeError, 1, None, numpy.ones([0], dtype=bool)),
+    ]
+)
+def test_errs__get_footprint(err_type, ndim, size, footprint):
+    with pytest.raises(err_type):
+        _utils._get_footprint(ndim, size=size, footprint=footprint)

--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -168,3 +168,16 @@ def test__get_size(expected, ndim, size):
 )
 def test__get_origin(expected, size, origin):
     assert expected == _utils._get_origin(size, origin)
+
+
+@pytest.mark.parametrize(
+    "expected, size, origin",
+    [
+        ((0,), (1,), 0),
+        ((1,), (3,), 0),
+        ((2,), (3,), 1),
+        ((2, 4), (3, 5), (1, 2)),
+    ]
+)
+def test__get_depth(expected, size, origin):
+    assert expected == _utils._get_depth(size, origin)

--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -131,3 +131,16 @@ def test_errs__get_origin(err_type, size, origin):
 def test_errs__get_footprint(err_type, ndim, size, footprint):
     with pytest.raises(err_type):
         _utils._get_footprint(ndim, size=size, footprint=footprint)
+
+
+@pytest.mark.parametrize(
+    "expected, ndim, depth, boundary",
+    [
+        (({0: 0}, {0: "reflect"}), 1, 0, "none"),
+        (({0: 0}, {0: "reflect"}), 1, 0, "reflect"),
+        (({0: 0}, {0: "periodic"}), 1, 0, "periodic"),
+        (({0: 1}, {0: "none"}), 1, 1, "none"),
+    ]
+)
+def test__get_depth_boundary(expected, ndim, depth, boundary):
+    assert expected == _utils._get_depth_boundary(ndim, depth, boundary)

--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -156,3 +156,15 @@ def test__get_depth_boundary(expected, ndim, depth, boundary):
 )
 def test__get_size(expected, ndim, size):
     assert expected == _utils._get_size(ndim, size)
+
+
+@pytest.mark.parametrize(
+    "expected, size, origin",
+    [
+        ((0,), (1,), 0),
+        ((1,), (3,), 1),
+        ((1, 2), (3, 5), (1, 2)),
+    ]
+)
+def test__get_origin(expected, size, origin):
+    assert expected == _utils._get_origin(size, origin)

--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -181,3 +181,14 @@ def test__get_origin(expected, size, origin):
 )
 def test__get_depth(expected, size, origin):
     assert expected == _utils._get_depth(size, origin)
+
+
+@pytest.mark.parametrize(
+    "expected, ndim, size, footprint",
+    [
+        (numpy.ones((2,), dtype=bool), 1, 2, None),
+        (numpy.ones((2,), dtype=bool), 1, None, numpy.ones((2,), dtype=bool)),
+    ]
+)
+def test__get_footprint(expected, ndim, size, footprint):
+    assert (expected == _utils._get_footprint(ndim, size, footprint)).all()

--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -144,3 +144,15 @@ def test_errs__get_footprint(err_type, ndim, size, footprint):
 )
 def test__get_depth_boundary(expected, ndim, depth, boundary):
     assert expected == _utils._get_depth_boundary(ndim, depth, boundary)
+
+
+@pytest.mark.parametrize(
+    "expected, ndim, size",
+    [
+        ((1,), 1, 1),
+        ((3, 3), 2, 3),
+        ((2, 4), 2, (2, 4)),
+    ]
+)
+def test__get_size(expected, ndim, size):
+    assert expected == _utils._get_size(ndim, size)


### PR DESCRIPTION
Adds some additional tests for the `dask_ndfilters._utils` module. This includes tests for various error cases and tests of the expected results. Provides full test coverage of `dask_ndfilters._utils` alone without testing functions that make use of these utility functions.